### PR TITLE
Metapackaging

### DIFF
--- a/hydra-configs-projects.txt
+++ b/hydra-configs-projects.txt
@@ -1,0 +1,2 @@
+hydra-configs-torch
+hydra-configs-torchvision

--- a/hydra-configs-torch/setup.py
+++ b/hydra-configs-torch/setup.py
@@ -3,10 +3,13 @@ from setuptools import find_namespace_packages, setup
 
 setup(
     name="hydra-configs-torch",
-    version="1.7.1",
+    version="1.6.1",
     packages=find_namespace_packages(include=["hydra_configs*"]),
     author=["Omry Yadan", "Rosario Scalise"],
     author_email=["omry@fb.com", "rosario@cs.uw.edu"],
     url="http://github.com/pytorch/hydra-torch",
     include_package_data=True,
+    install_requires=[
+        "omegaconf",
+    ],
 )

--- a/hydra-configs-torchvision/setup.py
+++ b/hydra-configs-torchvision/setup.py
@@ -9,4 +9,5 @@ setup(
     author_email=["omry@fb.com", "rosario@cs.uw.edu"],
     url="http://github.com/pytorch/hydra-torch",
     include_package_data=True,
+    install_requires=["omegaconf"],
 )

--- a/setup.py
+++ b/setup.py
@@ -1,23 +1,18 @@
 # Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
-import pathlib
+from setuptools import setup
 
-import pkg_resources
-from setuptools import find_namespace_packages, setup
-
-with pathlib.Path("requirements/requirements.txt").open() as requirements_txt:
-    install_requires = [
-        str(requirement)
-        for requirement in pkg_resources.parse_requirements(requirements_txt)
-    ]
-
+projects = [p.rstrip("\n") for p in open("hydra-configs-projects.txt", "r").readlines()]
+project_uris = [
+    f"{project} @ git+https://github.com/pytorch/hydra-torch/#subdirectory={project}"
+    for project in projects
+]
 
 setup(
     name="hydra-torch",
     version="0.9",
-    packages=find_namespace_packages(include=["hydra_configs.*"]),
     author=["Omry Yadan", "Rosario Scalise"],
     author_email=["omry@fb.com", "rosario@cs.uw.edu"],
     url="http://github.com/pytorch/hydra-torch",
     include_package_data=True,
-    install_requires=install_requires,
+    install_requires=project_uris,
 )


### PR DESCRIPTION
Installing from the root `setup.py` will now install the latest package for each project where `hydra-torch` is the name of the metapackage.

`pip install .` results in
`pip list` ->
```
Package                   Version
------------------------- -------
hydra-configs-torch       1.6.1
hydra-configs-torchvision 0.7.1
hydra-torch               0.9
omegaconf                 2.0.5
```

I also created a file called `hydra-torch-projects.txt` which will serve as an array that tracks the name of all currently maintained project. This centralizes the collection of active projects to one file that we can reference in other parts of the code.

Addresses #35 

Other note:
Currently, `install_requires` needs to use github URIs to get the project packages, but once these are on PyPI, we will change accordingly. The other option was configuring this to install from local dependency links after cloning, but it was far more complex.