### PR TITLE
[dev] Reorganize requirements

### DIFF
--- a/hydra-configs-torch/setup.py
+++ b/hydra-configs-torch/setup.py
@@ -1,6 +1,10 @@
 # Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
 from setuptools import find_namespace_packages, setup
 
+requirements = [
+    "omegaconf",
+]
+
 setup(
     name="hydra-configs-torch",
     version="1.6.1",
@@ -9,7 +13,5 @@ setup(
     author_email=["omry@fb.com", "rosario@cs.uw.edu"],
     url="http://github.com/pytorch/hydra-torch",
     include_package_data=True,
-    install_requires=[
-        "omegaconf",
-    ],
+    install_requires=requirements,
 )

--- a/hydra-configs-torchvision/setup.py
+++ b/hydra-configs-torchvision/setup.py
@@ -1,6 +1,10 @@
 # Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
 from setuptools import find_namespace_packages, setup
 
+requirements = [
+    "omegaconf",
+]
+
 setup(
     name="hydra-configs-torchvision",
     version="0.7.1",
@@ -9,5 +13,5 @@ setup(
     author_email=["omry@fb.com", "rosario@cs.uw.edu"],
     url="http://github.com/pytorch/hydra-torch",
     include_package_data=True,
-    install_requires=["omegaconf"],
+    install_requires=requirements,
 )

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -1,4 +1,7 @@
 -r requirements.txt
+torch==1.6
+torchvision==0.7
+hydra-configen==0.9.0.dev7
 black==20.8b1
 coverage
 flake8==3.8.4

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -1,4 +1,2 @@
-git+https://github.com/facebookresearch/hydra#subdirectory=tools/configen
-git+https://github.com/facebookresearch/hydra
-torch==1.6.0
-torchvision==0.7.0
+omegaconf==2.1.0dev20
+hydra-core==1.1.0dev3


### PR DESCRIPTION
Something blocking progress elsewhere is the moving target of hydra. Previously we were tracking `master`, but for the time being, we will pin `hydra==1.1.0dev3`.

In this PR, we are also proposing the following organization structure for requirements:

```bash
.
⋮
├── hydra-configs-projects.txt
├── hydra-configs-torch
│   ├── hydra_configs
⋮     ⋮
│   └── setup.py #specifies installing unconstrained `omegaconf`
├── hydra-configs-torchvision
│   ├── hydra_configs
⋮     ⋮
│   └── setup.py #specifies installing unconstrained `omegaconf`
├── requirements
│   ├── dev.txt #specifies installing all dev reqs like `nox` and `pytest` as well as pinned versions of `torch` and `torchvision`
│   └── requirements.txt #specifies installing pinned versions of `omegaconf` and `hydra-core`
└── setup.py #specifies installing only the projects listed in `hydra-configs-projects.txt` (unconstrained versions)

```
The reason for adding `omegaconf` to `setup.py` within each project package is that they depend only on `omegaconf` and could technically be installed on a stand-alone basis. Tests will only be run from the top level so the union of all dev requirements is kept at the top level as well.

An alternative would be to list the non-intersecting dev reqs in each project package constrained reqs separately (e.g. each package has its own `dev.txt`). Then when running tests, use the top level and project-specific dev reqs when per project.

This will address #59 
