### PR TITLE
[WIP] optim config registration function

### DIFF
--- a/examples/register_configs.py
+++ b/examples/register_configs.py
@@ -1,0 +1,18 @@
+# Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+import hydra
+from typing import Any
+from omegaconf import OmegaConf
+
+# registers all 'base' optimizer configs with configstore instance
+import hydra_configs.torch.optim
+
+hydra_configs.torch.optim.register_configs()
+
+
+@hydra.main(config_name="torch/optim/adam")
+def my_app(cfg: Any) -> None:
+    print(OmegaConf.to_yaml(cfg))
+
+
+if __name__ == "__main__":
+    my_app()

--- a/hydra-configs-torch/hydra_configs/torch/optim/__init__.py
+++ b/hydra-configs-torch/hydra_configs/torch/optim/__init__.py
@@ -1,3 +1,4 @@
+# Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
 # flake8: noqa
 # Mirrors torch/optim __init__ to allow for symmetric import structure
 from .adadelta import AdadeltaConf
@@ -13,6 +14,25 @@ from .rmsprop import RMSpropConf
 
 from .lbfgs import LBFGSConf
 from . import lr_scheduler
+
+from hydra.core.config_store import ConfigStore
+
+
+def register_configs():
+    cs = ConfigStore.instance()
+    cs.store(provider="torch", group="torch/optim", name="adadelta", node=AdadeltaConf)
+    cs.store(provider="torch", group="torch/optim", name="adagrad", node=AdagradConf)
+    cs.store(provider="torch", group="torch/optim", name="adam", node=AdamConf)
+    cs.store(provider="torch", group="torch/optim", name="adamw", node=AdamWConf)
+    cs.store(
+        provider="torch", group="torch/optim", name="sparseadam", node=SparseAdamConf
+    )
+    cs.store(provider="torch", group="torch/optim", name="adamax", node=AdamaxConf)
+    cs.store(provider="torch", group="torch/optim", name="asgd", node=ASGDConf)
+    cs.store(provider="torch", group="torch/optim", name="sgd", node=SGDConf)
+    cs.store(provider="torch", group="torch/optim", name="lbfgs", node=LBFGSConf)
+    cs.store(provider="torch", group="torch/optim", name="rprop", node=RpropConf)
+    cs.store(provider="torch", group="torch/optim", name="rmsprop", node=RMSpropConf)
 
 
 del adadelta


### PR DESCRIPTION
implements config registration for `optim` via `__init__.py`

If this looks good, I'll broadcast the same strategy across the rest of the configs we currently have.